### PR TITLE
`cached-fetch` - Fix Next.js compatibility: Default condition should be last one

### DIFF
--- a/cached-fetch/package.json
+++ b/cached-fetch/package.json
@@ -17,16 +17,16 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./astro": {
-      "default": "./dist/astro.js",
-      "types": "./dist/astro.d.ts"
+      "types": "./dist/astro.d.ts",
+      "default": "./dist/astro.js"
     },
     "./register": {
-      "default": "./dist/register.js",
-      "types": "./dist/register.d.ts"
+      "types": "./dist/register.d.ts",
+      "default": "./dist/register.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Next.js fails to import this module throwing the following error:

> Module not found: Default condition should be last one 

Applying this patch to the package.json locally does fix the issue.